### PR TITLE
Update setuptools-scm requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=83.0.0", "setuptools_scm>=10.0.5"]
+requires = ["setuptools>=83.0.0", "setuptools_scm>=10.2.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Completes the remaining setuptools-scm requirement update after Dependabot PR #256 conflicted with the already-merged dependency refresh. Dependabot PR #255 is already satisfied by merged PR #253.