### PR TITLE
Update setuptools requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=83.0.0", "setuptools_scm>=10.2.1"]
+requires = ["setuptools>=84.0.0", "setuptools_scm>=10.2.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Completes the refreshed setuptools requirement update to >=84.0.0 after Dependabot PR #255 was superseded by an earlier dependency merge.