### PR TITLE
Expand Ruff lint rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 """Configuration file for the Sphinx documentation builder."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from importlib.metadata import metadata
 from importlib.metadata import version as distribution_version
 
@@ -9,7 +9,7 @@ project = distribution["Name"]
 author = distribution.get("Author") or distribution.get("Author-email", "")
 version = distribution_version(project)
 release = version
-year = datetime.now().year
+year = datetime.now(UTC).year
 copyright = f"{year}, {author}"
 
 language = "en"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ select = [
     "E",    # pycodestyle
     "F",    # pyflakes
     "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions - comprehension improvements
+    "DTZ",  # flake8-datetimez - timezone-aware datetimes
+    "G",    # flake8-logging-format - logging formatting
+    "LOG",  # flake8-logging - logging best practices
     "W",    # pycodestyle warnings
     "I",    # isort - import sorting
     "UP",   # pyupgrade - modern Python idioms
@@ -102,13 +106,14 @@ select = [
     "SIM",  # flake8-simplify - code simplification
     "TID",  # flake8-tidy-imports - tidy imports
     "PTH",  # flake8-use-pathlib - pathlib usage
+    "PT",   # flake8-pytest-style - pytest conventions
+    "TC",   # flake8-type-checking - type-only imports
     "FLY",  # flynt - f-string conversion
     "PERF", # perflint - performance improvements
     "RUF",  # ruff-specific rules
 ]
 ignore = [
     "E501",    # Line length
-    "F403",    # Star imports
     "UP046",   # Generic class `Loader` uses `Generic` subclass instead of type parameters
     "S101",    # Allow assert
     "SIM103",  # Allow for True/False returns after a test
@@ -121,7 +126,6 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "PLR2004",
     "ANN",     # Annotations
     "S105",    # Possible hardcoded password
     "S108",    # Temp directory


### PR DESCRIPTION
Expands the template Ruff configuration with focused correctness, logging, pytest, and typing checks.

Also removes ineffective global exemptions and uses UTC for the documentation copyright year.