### PR TITLE
Strengthen ty type checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from importlib.metadata import version as distribution_version
 
 distribution = metadata("your-package-name")
 project = distribution["Name"]
-author = distribution.get("Author") or distribution.get("Author-email", "")
+author = distribution["Author"] or distribution["Author-email"]
 version = distribution_version(project)
 release = version
 year = datetime.now(UTC).year

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ relative_files = true
 omit = ["*/__pycache__/*"]
 
 [tool.ty.environment]
-python-version = "3.13"
+python-version = "3.11"
 
 [tool.ty.src]
 # Set include = ["src/your_package_name"] after adding the library package.
@@ -179,5 +179,8 @@ invalid-assignment = "error"
 invalid-method-override = "error"
 unresolved-attribute = "error"
 possibly-missing-attribute = "error"
-no-matching-overload = "ignore"
-unused-ignore-comment = "ignore"
+missing-type-argument = "error"
+no-matching-overload = "error"
+unsound-return-statement = "error"
+possibly-unresolved-reference = "warn"
+unused-ignore-comment = "error"


### PR DESCRIPTION
Strengthens the template type-checking policy for its Python 3.11 support floor.

- Detect missing generic arguments, unsafe returns, and invalid overload calls
- Surface unresolved references as warnings and stale ignore comments as errors
- Use the Python 3.11 metadata interface in the Sphinx configuration