### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+ARG VARIANT=3.13-bookworm
+FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT}
+
+RUN python -m pip install --no-cache-dir uv==0.10.7

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "Python Open Source Template",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "3.13-bookworm"
+    }
+  },
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "containerEnv": {
+    "UV_LINK_MODE": "copy"
+  },
+  "mounts": [
+    {
+      "source": "uv-cache-${devcontainerId}",
+      "target": "/home/vscode/.cache/uv",
+      "type": "volume"
+    }
+  ],
+  "postCreateCommand": "uv sync --all-groups --locked && uv run pre-commit install --install-hooks",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astral-sh.ty",
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "editor.codeActionsOnSave": {
+          "source.fixAll.ruff": "explicit",
+          "source.organizeImports.ruff": "explicit"
+        },
+        "editor.formatOnSave": true,
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
+        "python.testing.pytestEnabled": true
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ make verify  # Checks, tests, package build, and strict documentation build
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor guidance and
 [AGENTS.md](AGENTS.md) for agent instructions.
 
+## Dev Container
+
+Open the repository in a Dev Container to use the pinned Python and uv
+environment. It installs all dependency groups and the configured Git hooks on
+creation, while retaining the uv download cache between rebuilds.
+
 ## Documentation and Releases
 
 Documentation lives in `docs/` and is built with Sphinx using the Palewire


### PR DESCRIPTION
Adds a reproducible development container for the template.

- Pin Python 3.13 and uv 0.10.7
- Persist the uv cache across rebuilds
- Install all locked dependency groups and Git hooks automatically
- Configure VS Code support for Python, Ruff, ty, and YAML