### PR TITLE
Harden repository configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+*.gif binary
+*.jpeg binary
+*.jpg binary
+*.png binary
+*.webp binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Uncomment and replace this template with the maintainers for a derived project.
+#
+# * @palewire
+# /.github/ @palewire

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      python-dependencies:
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,5 +1,8 @@
 name: Continuous deployment
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "17 14 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
+    steps:
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Hardens repository defaults and contributor automation.

- Restrict CI token permissions and protect main
- Group Dependabot updates with weekly Actions checks
- Add Git attributes, a CODEOWNERS template, and Scorecard reporting