### PR TITLE
Guard placeholder package publishing

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -116,7 +116,10 @@ jobs:
     name: PyPI release
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags') &&
+      vars.PACKAGE_IMPORT_NAME != ''
     permissions:
       id-token: write
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Replace PyPI API tokens with trusted publishing and update GitHub Actions to
-  supported versions ([#261], [#262]).
+  supported versions, while skipping publication until a real package is
+  configured ([#261], [#262]).
 - Expand Ruff and ty checks, streamline pre-commit hooks, and improve the
   default pytest configuration ([#263], [#264], [#265], [#266]).
 - Document the required checks and approvals for post-merge GitHub releases


### PR DESCRIPTION
## Summary

Skip the tag-triggered PyPI publishing job until `PACKAGE_IMPORT_NAME` identifies a real package. This keeps GitHub-only template releases from attempting to publish the placeholder project.

## Acceptance Criteria

- [x] Git tags do not trigger placeholder package publication.
- [x] Configured packages retain trusted publishing.

## Validation

- `make verify`

## Documentation and Release Notes

- [x] Documentation is updated, or no update is needed.
- [x] `CHANGELOG.md` is updated for a user-facing, compatibility, or security change.